### PR TITLE
sprite saving and score saving

### DIFF
--- a/Fick_alpha.yyp/objects/oBonus/Collision_84faa312-87b6-4309-9972-e3255c45efc0.gml
+++ b/Fick_alpha.yyp/objects/oBonus/Collision_84faa312-87b6-4309-9972-e3255c45efc0.gml
@@ -1,6 +1,10 @@
 /// @description Insert description here
 // You can write your code in this editor
 global.bonusScr++;
+global.savedBonusScr++;
 global.bonusValue++;
+ini_open(working_directory + "stats.ini");
+ini_write_real("bonus","bonusScore",global.savedBonusScr);
+ini_close();
 audio_play_sound(snd_bonus,12,false);
 instance_destroy();

--- a/Fick_alpha.yyp/objects/oGlobalVariables/Create_0.gml
+++ b/Fick_alpha.yyp/objects/oGlobalVariables/Create_0.gml
@@ -2,11 +2,13 @@
 
 global.spriteSelect = 0; 
 //these should be false
+/*
 global.spriteUnlock1= true;
 global.spriteUnlock2= true;
 global.spriteUnlock3= true;
 global.spriteUnlock4= true;
 global.spriteUnlock5= true;
+*/
 /*
 if (file_exists("sPlayer1Unlock.dat"))
 {

--- a/Fick_alpha.yyp/objects/oP_Select_Helper/Mouse_4.gml
+++ b/Fick_alpha.yyp/objects/oP_Select_Helper/Mouse_4.gml
@@ -9,4 +9,7 @@ if (global.savedBonusScr > 20)
 	scSavePlayer();
 	scSaveScore();
 	//room_goto(start);
+	ini_open(working_directory + "stats.ini");
+	ini_write_real("sprite","Sprite1",true);
+	ini_close();
 }

--- a/Fick_alpha.yyp/objects/oP_Select_Helper1/Mouse_4.gml
+++ b/Fick_alpha.yyp/objects/oP_Select_Helper1/Mouse_4.gml
@@ -9,5 +9,8 @@ if (global.savedBonusScr > 20)
 	scSavePlayer();
 	scSaveScore();
 	//room_goto(start);
+	ini_open(working_directory + "stats.ini");
+	ini_write_real("sprite","Sprite2",true);
+	ini_close();
 }
 

--- a/Fick_alpha.yyp/objects/oP_Select_Helper2/Mouse_4.gml
+++ b/Fick_alpha.yyp/objects/oP_Select_Helper2/Mouse_4.gml
@@ -9,4 +9,7 @@ if (global.savedBonusScr > 20)
 	scSavePlayer();
 	scSaveScore();
 	//room_goto(start);
+	ini_open(working_directory + "stats.ini");
+	ini_write_real("sprite","Sprite3",true);
+	ini_close();
 }

--- a/Fick_alpha.yyp/objects/oPlayer/Other_0.gml
+++ b/Fick_alpha.yyp/objects/oPlayer/Other_0.gml
@@ -10,10 +10,12 @@ instance_create_layer(0, 0, "Instances", oCountdown);
 
 audio_play_sound(snd_complete,10,false);
 
+
 with(oPlayer) {
 x = xstart;
 y = ystart;
 }
 
 with(oPlayer) speed = 0;
+
 

--- a/Fick_alpha.yyp/objects/oSave/Create_0.gml
+++ b/Fick_alpha.yyp/objects/oSave/Create_0.gml
@@ -5,6 +5,12 @@ global.high_scr = 300;
 ini_open(working_directory + "stats.ini");
 //ini_write_real("tst","TST",500);
 global.high_scr = ini_read_real("score","SCORE",highscore_value(1));
+global.savedBonusScr = ini_read_real("bonus","bonusScore",0);
+global.spriteUnlock1= ini_read_real("sprite","Sprite1",false);
+global.spriteUnlock2= ini_read_real("sprite","Sprite2",false);
+global.spriteUnlock3= ini_read_real("sprite","Sprite3",false);
+global.spriteUnlock4= ini_read_real("sprite","Sprite4",false);
+global.spriteUnlock5= ini_read_real("sprite","Sprite5",false);
 ini_close();
 
 highscore_add("",global.high_scr);

--- a/Fick_alpha.yyp/objects/oScore/Draw_75.gml
+++ b/Fick_alpha.yyp/objects/oScore/Draw_75.gml
@@ -3,7 +3,7 @@ draw_set_color(c_white);
 draw_set_font(fScore);
 draw_text(32,12,"Level: "+ string(global.lvls));
 
-draw_text(32,49,"Ficks: " + string(global.bonusScr));
+draw_text(32,49,"Ficks: " + string(global.savedBonusScr));
 
 draw_text(32,90, "Test: 7.2");
 


### PR DESCRIPTION
Important: right now global.bonusScr isn't being used and needs to be removed.  Also when a new sprite is purchased the savedBonusScr is reduced by 20, but on the start of a new game it returns to the previous score